### PR TITLE
Use `execFileSync` instead of `sync-exec`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var execFile = require('child_process').execFile;
+var execFileSync = require('child_process').execFileSync;
 var execSync = require('sync-exec');
 
 function extractDarwin(line) {
@@ -103,6 +104,13 @@ module.exports.sync = function (username) {
 	if (process.platform === 'linux') {
 		return getUser(fs.readFileSync('/etc/passwd', 'utf8'), username);
 	} else if (process.platform === 'darwin') {
+		if (typeof execFileSync === 'function') {
+			return getUser(execFileSync('/usr/bin/id', ['-P', username], {
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'ignore']
+			}), username);
+		}
+
 		return getUser(execSync('/usr/bin/id -P "' + username + '"').stdout, username);
 	} else {
 		throw new Error('Platform not supported');


### PR DESCRIPTION
Probably needs to be tested on OS X first.

Fixes #3.